### PR TITLE
feat: add VLC player support for Linux and Windows

### DIFF
--- a/core/player.go
+++ b/core/player.go
@@ -69,7 +69,32 @@ func Play(url, title, referer, userAgent string, subtitles []string) error {
 
 	default:
 		cfg := LoadConfig()
-		if cfg.Player == "mpv" {
+		if cfg.Player == "vlc" {
+			vlc_executable := "vlc"
+			if runtime.GOOS == "windows" {
+				vlc_executable = "vlc.exe"
+			}
+
+			args := []string{
+				url,
+				fmt.Sprintf("--http-referrer=%s", referer),
+				fmt.Sprintf("--http-user-agent=%s", userAgent),
+				fmt.Sprintf("--meta-title=Playing %s", title),
+			}
+			for _, sub := range subtitles {
+				if sub != "" {
+					// Use --input-slave for remote subtitle URLs
+					if strings.HasPrefix(sub, "http://") || strings.HasPrefix(sub, "https://") {
+						args = append(args, fmt.Sprintf("--input-slave=%s", sub))
+					} else {
+						args = append(args, fmt.Sprintf("--sub-file=%s", sub))
+					}
+				}
+			}
+
+			cmd = exec.Command(vlc_executable, args...)
+		} else {
+			// Default to mpv
 			args := []string{
 				url,
 				fmt.Sprintf("--referrer=%s", referer),


### PR DESCRIPTION
Closes #1

## Summary
- Adds VLC as an alternative player option configurable via `config.yaml`
- Uses `--input-slave` for remote subtitle URLs (http/https) and `--sub-file` for local files
- Supports both Linux and Windows (vlc/vlc.exe)

**⚠️ Warning: This has only been tested on Arch Linux (EndeavourOS). Testing on other distributions and Windows would be appreciated.**

## Usage
Set `player: vlc` in `~/.config/luffy/config.yaml`:
```yaml
player: vlc
```

## Test plan
- [x] Tested on Arch Linux (EndeavourOS) with VLC 3.0.21
- [x] Verified HLS stream playback works
- [x] Verified remote subtitles load correctly via `--input-slave`
- [x] Verified referrer and user-agent headers are passed

🤖 Generated with [Claude Code](https://claude.ai/code)