### PR TITLE
feat: add download metadata display table

### DIFF
--- a/core/downloader.go
+++ b/core/downloader.go
@@ -1,16 +1,158 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
+
+type DownloadMetadata struct {
+	Title       string
+	Duration    string
+	Filesize    int64
+	Format      string
+	Resolution  string
+	Filename    string
+	Destination string
+}
+
+func getDownloadMetadata(url, referer, userAgent string) (*DownloadMetadata, error) {
+	args := []string{
+		url,
+		"--dump-single-json",
+		"--skip-download",
+		"--referer", referer,
+		"--user-agent", userAgent,
+		"--no-warnings",
+	}
+
+	cmd := exec.Command("yt-dlp", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to fetch metadata: %w", err)
+	}
+
+	var info struct {
+		Title      string `json:"title"`
+		Duration   int64  `json:"duration"`
+		Filesize   int64  `json:"filesize"`
+		Format     string `json:"format"`
+		Resolution string `json:"resolution"`
+		Filename   string `json:"_filename"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &info); err != nil {
+		return nil, fmt.Errorf("failed to parse metadata: %w", err)
+	}
+
+	duration := fmt.Sprintf("%d:%02d", info.Duration/60, info.Duration%60)
+	if info.Duration/3600 > 0 {
+		duration = fmt.Sprintf("%d:%02d:%02d", info.Duration/3600, (info.Duration%3600)/60, info.Duration%60)
+	}
+
+	return &DownloadMetadata{
+		Title:       info.Title,
+		Duration:    duration,
+		Filesize:    info.Filesize,
+		Format:      info.Format,
+		Resolution:  info.Resolution,
+		Filename:    info.Filename,
+		Destination: info.Filename,
+	}, nil
+}
+
+func getTerminalWidth() int {
+	if runtime.GOOS == "windows" {
+		return 80
+	}
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return 80
+	}
+	parts := strings.Split(string(out), " ")
+	if len(parts) < 2 {
+		return 80
+	}
+	width := 0
+	fmt.Sscanf(parts[1], "%d", &width)
+	if width == 0 {
+		return 80
+	}
+	return width
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func displayDownloadTable(meta *DownloadMetadata) {
+	termWidth := getTerminalWidth()
+	if termWidth < 60 {
+		termWidth = 60
+	}
+
+	maxValueLen := termWidth - 20
+	if maxValueLen < 30 {
+		maxValueLen = 30
+	}
+
+	fmt.Println("\nDownload Information:")
+	fmt.Println(strings.Repeat("─", termWidth))
+
+	fmt.Printf("%-12s %s\n", "Property", "Value")
+	fmt.Println(strings.Repeat("─", termWidth))
+
+	displayField("Title", meta.Title, maxValueLen)
+	displayField("Duration", meta.Duration, maxValueLen)
+	displayField("Size", formatSize(meta.Filesize), maxValueLen)
+	displayField("Format", meta.Format, maxValueLen)
+	displayField("Resolution", meta.Resolution, maxValueLen)
+	displayField("Destination", meta.Destination, maxValueLen)
+
+	fmt.Println(strings.Repeat("─", termWidth))
+	fmt.Println()
+}
+
+func displayField(label, value string, maxLen int) {
+	if len(value) > maxLen {
+		value = truncate(value, maxLen)
+	}
+	fmt.Printf("%-12s %s\n", label, value)
+}
+
+func formatSize(bytes int64) string {
+	if bytes == 0 {
+		return "unknown"
+	}
+	const (
+		MB = 1024 * 1024
+		GB = 1024 * 1024 * 1024
+	)
+	switch {
+	case bytes >= GB:
+		return fmt.Sprintf("%.2f GB", float64(bytes)/float64(GB))
+	case bytes >= MB:
+		return fmt.Sprintf("%.2f MB", float64(bytes)/float64(MB))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
 
 func Download(basePath, dlPath, name, url, referer, userAgent string, subtitles []string, debug bool) error {
 	if dlPath == "" {
@@ -26,6 +168,15 @@ func Download(basePath, dlPath, name, url, referer, userAgent string, subtitles 
 	cleanName = strings.ReplaceAll(cleanName, "\"", "")
 
 	outputTemplate := filepath.Join(dlPath, cleanName+".mp4")
+
+	fmt.Println("[download] Fetching metadata...")
+	meta, err := getDownloadMetadata(url, referer, userAgent)
+	if err != nil {
+		fmt.Printf("[warning] Could not fetch metadata: %v\n", err)
+	} else {
+		meta.Destination = outputTemplate
+		displayDownloadTable(meta)
+	}
 
 	args := []string{
 		url,


### PR DESCRIPTION
- Display download metadata in a clean, responsive table before downloading
- Shows: title, duration, size, format, resolution, and destination path
- Automatically adapts to terminal width with smart truncation

<img width="638" height="313" alt="Screenshot 2026-02-15 at 12 03 08 PM" src="https://github.com/user-attachments/assets/db68f6c7-889b-4c6c-922a-6113e6fc1e2a" />

