### PR TITLE
fix: pass Cineby subtitles to player

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -834,6 +834,22 @@ func resolveStreamURL(
 		strings.EqualFold(providerName, "streamsrc") || strings.EqualFold(providerName, "internetarchive") ||
 		strings.EqualFold(providerName, "cineby") {
 		streamURL = link
+		if idx := strings.Index(streamURL, "|subs="); idx != -1 {
+			subsStr := streamURL[idx+6:]
+			streamURL = streamURL[:idx]
+			if decoded, decodeErr := url.QueryUnescape(subsStr); decodeErr == nil {
+				subsStr = decoded
+			}
+			sep := ","
+			if strings.Contains(subsStr, "\n") {
+				sep = "\n"
+			}
+			for _, sub := range strings.Split(subsStr, sep) {
+				if sub = strings.TrimSpace(sub); sub != "" {
+					subtitles = append(subtitles, sub)
+				}
+			}
+		}
 	} else {
 		if debugMode {
 			fmt.Println("Decrypting stream...")
@@ -875,7 +891,20 @@ func resolveStreamURL(
 			if debugMode {
 				fmt.Printf("Failed to parse m3u8: %v\n", qErr)
 			}
-		} else if len(qualities) > 0 {
+		} else {
+			hlsSubtitles, subErr := core.GetSubtitles(streamURL, ctx.Client, referer)
+			if subErr != nil {
+				if debugMode {
+					fmt.Printf("Failed to parse m3u8 subtitles: %v\n", subErr)
+				}
+			} else if len(hlsSubtitles) > 0 {
+				subtitles = appendUniqueStrings(subtitles, hlsSubtitles...)
+				if debugMode {
+					fmt.Printf("Found %d HLS subtitle tracks\n", len(hlsSubtitles))
+				}
+			}
+		}
+		if qErr == nil && len(qualities) > 0 {
 			if debugMode {
 				fmt.Printf("Found %d quality variants\n", len(qualities))
 			}
@@ -893,6 +922,21 @@ func resolveStreamURL(
 		}
 	}
 	return
+}
+
+func appendUniqueStrings(values []string, candidates ...string) []string {
+	seen := make(map[string]bool, len(values)+len(candidates))
+	for _, value := range values {
+		seen[value] = true
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate != "" && !seen[candidate] {
+			seen[candidate] = true
+			values = append(values, candidate)
+		}
+	}
+	return values
 }
 
 // getLinkForEpisode resolves the raw provider link for a given episodeWithNum.

--- a/core/m3u8.go
+++ b/core/m3u8.go
@@ -120,6 +120,121 @@ func GetQualities(m3u8URL string, client *http.Client, referer string) ([]Qualit
 	return nil, sanitizeMediaURL(m3u8URL), nil
 }
 
+func GetSubtitles(m3u8URL string, client *http.Client, referer string) ([]string, error) {
+	m3u8URL = sanitizeMediaURL(m3u8URL)
+
+	req, err := http.NewRequest("GET", m3u8URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to fetch m3u8 subtitles: %d", resp.StatusCode)
+	}
+
+	baseURL, err := url.Parse(m3u8URL)
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	var all []string
+	var preferred []string
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "#EXT-X-MEDIA:") {
+			continue
+		}
+
+		attrs := parseM3U8Attributes(strings.TrimPrefix(line, "#EXT-X-MEDIA:"))
+		if !strings.EqualFold(attrs["TYPE"], "SUBTITLES") || attrs["URI"] == "" {
+			continue
+		}
+
+		resolvedURL := sanitizeMediaURL(attrs["URI"])
+		u, err := url.Parse(resolvedURL)
+		if err == nil {
+			resolvedURL = baseURL.ResolveReference(u).String()
+		}
+
+		all = appendUnique(all, resolvedURL)
+		if isEnglishSubtitle(attrs["LANGUAGE"], attrs["NAME"]) {
+			preferred = appendUnique(preferred, resolvedURL)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(preferred) > 0 {
+		return preferred, nil
+	}
+	return all, nil
+}
+
+func parseM3U8Attributes(text string) map[string]string {
+	attrs := make(map[string]string)
+	for _, part := range splitM3U8AttributeList(text) {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+		if key != "" {
+			attrs[key] = value
+		}
+	}
+	return attrs
+}
+
+func splitM3U8AttributeList(text string) []string {
+	var parts []string
+	start := 0
+	inQuotes := false
+	for i, r := range text {
+		switch r {
+		case '"':
+			inQuotes = !inQuotes
+		case ',':
+			if !inQuotes {
+				parts = append(parts, text[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, text[start:])
+	return parts
+}
+
+func isEnglishSubtitle(language, name string) bool {
+	language = strings.ToLower(strings.TrimSpace(language))
+	name = strings.ToLower(strings.TrimSpace(name))
+	return language == "en" || strings.HasPrefix(language, "en-") || language == "eng" ||
+		strings.Contains(name, "english") || name == "eng"
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
 func formatBandwidth(bandwidth int) string {
 	if bandwidth >= 1000000 {
 		return fmt.Sprintf("%.1f Mbps", float64(bandwidth)/1000000)

--- a/core/m3u8_test.go
+++ b/core/m3u8_test.go
@@ -1,0 +1,26 @@
+package core
+
+import "testing"
+
+func TestParseM3U8SubtitleAttributesWithQuotedComma(t *testing.T) {
+	attrs := parseM3U8Attributes(`TYPE=SUBTITLES,GROUP-ID="subs",NAME="English, CC",LANGUAGE="en",URI="subtitles/eng/prog_index.m3u8"`)
+
+	if attrs["TYPE"] != "SUBTITLES" {
+		t.Fatalf("TYPE = %q, want SUBTITLES", attrs["TYPE"])
+	}
+	if attrs["NAME"] != "English, CC" {
+		t.Fatalf("NAME = %q, want English, CC", attrs["NAME"])
+	}
+	if attrs["URI"] != "subtitles/eng/prog_index.m3u8" {
+		t.Fatalf("URI = %q, want subtitles/eng/prog_index.m3u8", attrs["URI"])
+	}
+}
+
+func TestIsEnglishSubtitle(t *testing.T) {
+	if !isEnglishSubtitle("en", "English") {
+		t.Fatal("expected en/English to be treated as English")
+	}
+	if isEnglishSubtitle("fr", "French") {
+		t.Fatal("expected fr/French not to be treated as English")
+	}
+}

--- a/core/providers/cineby.go
+++ b/core/providers/cineby.go
@@ -219,12 +219,15 @@ func (c *Cineby) GetServers(episodeID string) ([]core.Server, error) {
 }
 
 func (c *Cineby) GetLink(serverID string) (string, error) {
-	return resolveVidKingEmbed(serverID)
+	return resolveVidKingEmbed(serverID, c.Client)
 }
 
-func resolveVidKingEmbed(embedURL string) (string, error) {
+func resolveVidKingEmbed(embedURL string, client *http.Client) (string, error) {
 	if _, err := exec.LookPath("agent-browser"); err != nil {
 		return "", fmt.Errorf("agent-browser is required to resolve VidKing embeds: %w", err)
+	}
+	if client == nil {
+		client = http.DefaultClient
 	}
 
 	if !strings.Contains(embedURL, "autoPlay=") {
@@ -246,27 +249,134 @@ func resolveVidKingEmbed(embedURL string) (string, error) {
 		return "", fmt.Errorf("failed waiting for VidKing playback: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
-	script := `JSON.stringify(performance.getEntriesByType('resource').map(r => r.name).filter(n => /\.m3u8(\?|$)/i.test(n)))`
+	script := `JSON.stringify({
+		m3u8s: performance.getEntriesByType('resource').map(r => r.name).filter(n => /\.m3u8(\?|$)/i.test(n)),
+		subtitles: [
+			...performance.getEntriesByType('resource').map(r => r.name).filter(n => /(\.(vtt|srt|ass)(\?|$)|\/(subtitles?|captions?)([/?#]|$))/i.test(n)),
+			...Array.from(document.querySelectorAll('track[src]')).map(t => t.src)
+		],
+		subtitleAPIs: performance.getEntriesByType('resource').map(r => r.name).filter(n => /^https?:\/\/sub\.wyzie\.io\/search/i.test(n))
+	})`
 	output, err := exec.CommandContext(ctx, "agent-browser", append(sessionArgs, "eval", script)...).CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect VidKing resources: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
-	m3u8s := extractM3U8URLs(string(output))
+	m3u8s, subtitles, subtitleAPIs := extractVidKingURLs(string(output))
 	if len(m3u8s) == 0 {
 		return "", fmt.Errorf("no playable m3u8 found in VidKing embed")
 	}
+	for _, apiURL := range subtitleAPIs {
+		apiSubtitles, err := fetchWyzieSubtitles(apiURL, client)
+		if err != nil {
+			continue
+		}
+		subtitles = append(subtitles, apiSubtitles...)
+	}
+	subtitles = dedupeURLs(subtitles)
+	if len(subtitles) > 0 {
+		return m3u8s[0] + "|subs=" + url.QueryEscape(strings.Join(subtitles, "\n")), nil
+	}
 	return m3u8s[0], nil
+}
+
+func extractVidKingURLs(text string) ([]string, []string, []string) {
+	var payload struct {
+		M3U8s        []string `json:"m3u8s"`
+		Subtitles    []string `json:"subtitles"`
+		SubtitleAPIs []string `json:"subtitleAPIs"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(text)), &payload); err == nil {
+		return dedupeURLs(payload.M3U8s), dedupeURLs(payload.Subtitles), dedupeURLs(payload.SubtitleAPIs)
+	}
+	return extractM3U8URLs(text), extractSubtitleURLs(text), extractSubtitleAPIURLs(text)
 }
 
 func extractM3U8URLs(text string) []string {
 	re := regexp.MustCompile(`https?://[^"\\\s]+\.m3u8[^"\\\s]*`)
 	matches := re.FindAllString(text, -1)
+	return dedupeURLs(matches)
+}
+
+func extractSubtitleURLs(text string) []string {
+	re := regexp.MustCompile(`https?://[^"\\\s]+(?:\.(?:vtt|srt|ass)(?:\?[^"\\\s]*)?|/(?:subtitles?|captions?)(?:[/?#][^"\\\s]*)?)`)
+	matches := re.FindAllString(text, -1)
+	return dedupeURLs(matches)
+}
+
+func extractSubtitleAPIURLs(text string) []string {
+	re := regexp.MustCompile(`https?://sub\.wyzie\.io/search[^"\\\s]+`)
+	matches := re.FindAllString(text, -1)
+	return dedupeURLs(matches)
+}
+
+func fetchWyzieSubtitles(apiURL string, client *http.Client) ([]string, error) {
+	req, err := core.NewRequest("GET", apiURL)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Referer", VIDKING_BASE_URL+"/")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to fetch subtitles: %d", resp.StatusCode)
+	}
+
+	var tracks []struct {
+		URL               string `json:"url"`
+		Language          string `json:"language"`
+		Display           string `json:"display"`
+		IsHearingImpaired bool   `json:"isHearingImpaired"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tracks); err != nil {
+		return nil, err
+	}
+
+	var english []string
+	var englishHI []string
+	var fallback []string
+	for _, track := range tracks {
+		if track.URL == "" {
+			continue
+		}
+		if isEnglishSubtitle(track.Language, track.Display) {
+			if track.IsHearingImpaired {
+				englishHI = append(englishHI, track.URL)
+			} else {
+				english = append(english, track.URL)
+			}
+			continue
+		}
+		fallback = append(fallback, track.URL)
+	}
+	if len(english) > 0 {
+		return dedupeURLs(english), nil
+	}
+	if len(englishHI) > 0 {
+		return dedupeURLs(englishHI), nil
+	}
+	return dedupeURLs(fallback), nil
+}
+
+func isEnglishSubtitle(language, display string) bool {
+	language = strings.ToLower(strings.TrimSpace(language))
+	display = strings.ToLower(strings.TrimSpace(display))
+	return language == "en" || language == "eng" || strings.HasPrefix(language, "en-") ||
+		strings.Contains(display, "english")
+}
+
+func dedupeURLs(matches []string) []string {
 	seen := make(map[string]bool, len(matches))
 	urls := make([]string, 0, len(matches))
 	for _, match := range matches {
 		match = strings.ReplaceAll(match, `\/`, `/`)
 		match = strings.ReplaceAll(match, `\u0026`, `&`)
+		match = strings.TrimSpace(match)
 		if !seen[match] {
 			seen[match] = true
 			urls = append(urls, match)


### PR DESCRIPTION
## Summary
- resolve VidKing/Wyzie subtitle API responses into playable subtitle file URLs
- preserve direct resource subtitles and HLS subtitle tracks during quality selection
- add coverage for quoted HLS subtitle attribute parsing

## Validation
- env GOCACHE=/tmp/luffy-pr-go-cache go test ./...
- env GOCACHE=/tmp/luffy-pr-go-cache go build .

## Note
- env GOCACHE=/tmp/luffy-pr-go-cache go vet ./... still reports a pre-existing issue in core/providers/hdrezka.go:196 (using resp before checking for errors), unrelated to this change.