### PR TITLE
fix(player): preserve caller-owned subtitle files

### DIFF
--- a/core/player.go
+++ b/core/player.go
@@ -267,14 +267,6 @@ func readPositionViaIPC(client *gopv.Client) float64 {
 func Play(url, title, referer, userAgent string, subtitles []string, debug bool, startSecs float64, hctx HookContext) (float64, error) {
 	cfg := LoadConfig()
 
-	defer func() {
-		for _, sub := range subtitles {
-			if sub != "" && strings.HasPrefix(sub, os.TempDir()) {
-				os.Remove(sub)
-			}
-		}
-	}()
-
 	hctx.StreamURL = url
 	hctx.Action = "play"
 	RunHook(cfg.Hooks.OnPlay, hctx, debug)
@@ -431,14 +423,6 @@ type PlayResult struct {
 // Returns a PlayResult containing the chosen action and the last tracked position.
 func PlayWithControls(url, title, referer, userAgent string, subtitles []string, debug bool, startSecs float64, hctx HookContext) (PlayResult, error) {
 	cfg := LoadConfig()
-
-	defer func() {
-		for _, sub := range subtitles {
-			if sub != "" && strings.HasPrefix(sub, os.TempDir()) {
-				os.Remove(sub)
-			}
-		}
-	}()
 
 	for {
 		fmt.Printf("Starting player for %s...\n", title)

--- a/core/player_test.go
+++ b/core/player_test.go
@@ -1,0 +1,104 @@
+//go:build linux
+
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPlaybackPreservesSuppliedSubtitles(t *testing.T) {
+	// Keep config/hooks and all deletion targets inside disposable fixtures.
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	tmp := filepath.Join(root, "tmp")
+	bin := filepath.Join(root, "bin")
+	for _, dir := range []string{tmp, bin, tmp + "-other"} {
+		if err := os.Mkdir(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("TMPDIR", tmp)
+	t.Setenv("PATH", bin)
+	argsFile := filepath.Join(root, "args")
+	t.Setenv("LUFFY_TEST_ARGS", argsFile)
+
+	// Avoid an interactive fzf menu even when go test runs from a terminal.
+	stdin, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() { os.Stdin = oldStdin; stdin.Close() })
+
+	paths := []string{
+		filepath.Join(tmp, "local.srt"),
+		tmp + "/../outside.srt", // Preserve traversal; filepath.Join would clean it.
+		filepath.Join(tmp+"-other", "prefix.srt"),
+	}
+	subtitles := append([]string{"", "https://example.invalid/subtitles.vtt"}, paths...)
+	for _, entry := range []string{"Play", "PlayWithControls"} {
+		for _, launch := range []string{"success", "failure"} {
+			t.Run(entry+"/"+launch, func(t *testing.T) {
+				player := filepath.Join(bin, "mpv")
+				if launch == "success" {
+					// Capture forwarding and leave an IPC fixture for the owner to clean.
+					script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$LUFFY_TEST_ARGS\"\nfor arg do\n case $arg in --input-ipc-server=*) : > \"${arg#--input-ipc-server=}\";; esac\ndone\n"
+					if err := os.WriteFile(player, []byte(script), 0700); err != nil {
+						t.Fatal(err)
+					}
+				} else if err := os.Remove(player); err != nil && !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+				for _, path := range paths {
+					if err := os.WriteFile(path, []byte("caller-owned subtitle"), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				var playErr error
+				if entry == "Play" {
+					_, playErr = Play("https://example.invalid/video", "test", "", "", subtitles, false, 0, HookContext{})
+				} else {
+					_, playErr = PlayWithControls("https://example.invalid/video", "test", "", "", subtitles, false, 0, HookContext{})
+				}
+				if launch == "success" && playErr != nil {
+					t.Fatal(playErr)
+				}
+				if launch == "failure" && (playErr == nil || !strings.Contains(playErr.Error(), "failed to start player")) {
+					t.Fatalf("expected startup failure, got %v", playErr)
+				}
+				for _, path := range paths {
+					data, err := os.ReadFile(path)
+					if err != nil || string(data) != "caller-owned subtitle" {
+						t.Errorf("supplied file %q was deleted or changed: %q, %v", path, data, err)
+					}
+				}
+				if launch == "success" {
+					data, err := os.ReadFile(argsFile)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, sub := range subtitles[1:] {
+						if !strings.Contains(string(data), "--sub-file="+sub+"\n") {
+							t.Errorf("subtitle %q was not forwarded", sub)
+						}
+					}
+					if strings.Contains(string(data), "--sub-file=\n") {
+						t.Error("empty subtitle was forwarded")
+					}
+				}
+				entries, err := os.ReadDir(filepath.Join(tmp, "mpvsockets"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(entries) != 0 {
+					t.Errorf("IPC fixtures were not cleaned: %v", entries)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
`Play` and `PlayWithControls` currently delete supplied subtitle paths on return whenever the string starts with `os.TempDir()`. That prefix does not establish file ownership or directory containment: a provider-supplied traversal or prefix-sibling path can delete an unrelated file, even when the player fails to start.

This removes the two subtitle-cleanup defers. Neither playback function creates those files, and `FetchOpenSubtitles`, the helper that creates temporary subtitles, has no callers in the current application. Subtitle forwarding, hooks, and cleanup of generated IPC paths remain unchanged.

The added Linux regression test covers both entry points with successful and failed launches. It checks caller-owned temporary files, traversal paths, and prefix-sibling paths, plus local/remote subtitle forwarding, empty-subtitle handling, and IPC cleanup. Fixtures use disposable directories and a fake player without network access.

Validation on Linux amd64 with Go 1.26.8:

- Regression failed on the original source in all four subcases, then passed with this patch.
- `CGO_ENABLED=0 go test ./... -count=1` passed, including independently selected failure subtests.
- `CGO_ENABLED=0 go vet ./...` and `CGO_ENABLED=0 go build -trimpath -o builds/luffy .` passed.
- An installed build of this commit played three seconds of the official Blender Big Buck Bunny sample through YouTube/mpv with null audio/video outputs and normal EOF.

Other platforms were not runtime-tested. This addresses the subtitle deletion finding, not a comprehensive security audit.

Disclosure: Codex authored and reviewed the patch, wrote this description, and submitted this PR at the fork owner's explicit request. This is not represented as human-authored or independently human-reviewed work.
