### PR TITLE
feat(player): add audio_delay config; repair player test broken by #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ dl_path: ""
 # to always auto-select the highest available quality.
 quality: ""
 
+# Shift audio relative to video (seconds; positive delays audio, negative
+# advances it) — use if a stream's audio plays slightly early/late.
+audio_delay: 0
+
 # Extra arguments appended to every mpv invocation (ignored on VLC/IINA/Android).
 # mpv_args:
 #   - "--hwdec=auto"

--- a/core/config.go
+++ b/core/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	Provider     string `yaml:"provider"`
 	DlPath       string `yaml:"dl_path"`
 	Quality      string `yaml:"quality"`
+	// AudioDelay shifts audio relative to video in seconds for mpv: positive
+	// values delay audio (use when audio plays early), negative advance it.
+	AudioDelay float64 `yaml:"audio_delay"`
 	// MpvArgs holds extra command-line arguments appended to every mpv invocation.
 	// Example: ["--hwdec=auto", "--volume=80"]
 	MpvArgs []string    `yaml:"mpv_args"`

--- a/core/player.go
+++ b/core/player.go
@@ -145,6 +145,9 @@ func buildPlayerCmd(url, title, referer, userAgent, origin string, subtitles []s
 			if origin != "" {
 				args = append(args, fmt.Sprintf("--http-header-fields=Origin: %s", origin))
 			}
+			if cfg.AudioDelay != 0 {
+				args = append(args, fmt.Sprintf("--audio-delay=%g", cfg.AudioDelay))
+			}
 			for _, sub := range subtitles {
 				if sub != "" {
 					args = append(args, fmt.Sprintf("--sub-file=%s", sub))
@@ -206,6 +209,9 @@ func buildPlayerCmd(url, title, referer, userAgent, origin string, subtitles []s
 			}
 			if origin != "" {
 				args = append(args, fmt.Sprintf("--http-header-fields=Origin: %s", origin))
+			}
+			if cfg.AudioDelay != 0 {
+				args = append(args, fmt.Sprintf("--audio-delay=%g", cfg.AudioDelay))
 			}
 			for _, sub := range subtitles {
 				if sub != "" {

--- a/core/player_test.go
+++ b/core/player_test.go
@@ -25,6 +25,15 @@ func TestPlaybackPreservesSuppliedSubtitles(t *testing.T) {
 	argsFile := filepath.Join(root, "args")
 	t.Setenv("LUFFY_TEST_ARGS", argsFile)
 
+	// Fixture config: exercise audio_delay forwarding to the player.
+	cfgDir := filepath.Join(root, ".config", "luffy")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("audio_delay: 0.25\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
 	// Avoid an interactive fzf menu even when go test runs from a terminal.
 	stdin, err := os.Open(os.DevNull)
 	if err != nil {
@@ -45,8 +54,14 @@ func TestPlaybackPreservesSuppliedSubtitles(t *testing.T) {
 			t.Run(entry+"/"+launch, func(t *testing.T) {
 				player := filepath.Join(bin, "mpv")
 				if launch == "success" {
-					// Capture forwarding and leave an IPC fixture for the owner to clean.
-					script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$LUFFY_TEST_ARGS\"\nfor arg do\n case $arg in --input-ipc-server=*) : > \"${arg#--input-ipc-server=}\";; esac\ndone\n"
+					// Capture forwarding, leave an IPC fixture for the owner to
+					// clean, and stay alive so PlayWithControls treats the
+					// player as started before showing its control menu. The
+					// isolated PATH needs a sleep stub for the script.
+					if err := os.WriteFile(filepath.Join(bin, "sleep"), []byte("#!/bin/sh\nexec /usr/bin/sleep \"$@\"\n"), 0700); err != nil {
+						t.Fatal(err)
+					}
+					script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$LUFFY_TEST_ARGS\"\nfor arg do\n case $arg in --input-ipc-server=*) : > \"${arg#--input-ipc-server=}\";; esac\ndone\nsleep 5\n"
 					if err := os.WriteFile(player, []byte(script), 0700); err != nil {
 						t.Fatal(err)
 					}
@@ -61,9 +76,9 @@ func TestPlaybackPreservesSuppliedSubtitles(t *testing.T) {
 
 				var playErr error
 				if entry == "Play" {
-					_, playErr = Play("https://example.invalid/video", "test", "", "", subtitles, false, 0, HookContext{})
+					_, playErr = Play("https://example.invalid/video", "test", "", "", "", subtitles, false, 0, HookContext{})
 				} else {
-					_, playErr = PlayWithControls("https://example.invalid/video", "test", "", "", subtitles, false, 0, HookContext{})
+					_, playErr = PlayWithControls("https://example.invalid/video", "test", "", "", "", subtitles, false, 0, HookContext{})
 				}
 				if launch == "success" && playErr != nil {
 					t.Fatal(playErr)
@@ -89,6 +104,9 @@ func TestPlaybackPreservesSuppliedSubtitles(t *testing.T) {
 					}
 					if strings.Contains(string(data), "--sub-file=\n") {
 						t.Error("empty subtitle was forwarded")
+					}
+					if !strings.Contains(string(data), "--audio-delay=0.25\n") {
+						t.Error("audio_delay was not forwarded to the player")
 					}
 				}
 				entries, err := os.ReadDir(filepath.Join(tmp, "mpvsockets"))

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ If the file does not exist, cannot be read, or contains invalid YAML, `LoadConfi
 | `provider` | `"flixhq"` | Default search provider when `--provider` flag is not given |
 | `dl_path` | `""` | Download destination; empty means the user's home directory |
 | `quality` | `""` | Empty means show fzf prompt; set to `"best"` to auto-select highest quality |
+| `audio_delay` | `0` | mpv audio delay in seconds; positive delays audio (use when audio plays early), negative advances it |
 | `mpv_args` | `[]` | Extra CLI arguments appended to every mpv invocation |
 | `hooks.on_play` | `""` | Shell command run before the player launches |
 | `hooks.on_exit` | `""` | Shell command run after the player exits |


### PR DESCRIPTION
## Summary

Adds an `audio_delay` config option and repairs the player test that the #40/#41 merge left broken.

## Changes

- **`audio_delay`** (seconds, default `0`) — passed to mpv as `--audio-delay`. Positive values delay audio, negative advance it; useful when a provider's stream carries audio slightly ahead of or behind the video. Documented in `docs/config.md` and the README config example.
- **Test repair**: `core/player_test.go` no longer compiled after #41 ( `Play`/`PlayWithControls` gained the `origin` parameter) and its fake player exited immediately, which the new 3-second startup window now treats as an error — so the test never reached the menu path. The fixture now supplies the `origin` argument, keeps the fake player alive for the startup window, and asserts that `--audio-delay` is forwarded.

## Verification

- `go test ./...` and `go vet ./...` pass on this branch.
- New assertion covers `audio_delay` forwarding; existing subtitle-preservation coverage still runs (and passes) for both `Play` and `PlayWithControls`, success and startup-failure paths.

## Notes

- AI-assistance disclosure: implemented with AI assistance and reviewed/submitted by the maintainer of the MADPANDA3D fork, per the repo's AI usage policy. The human is responsible for the submission.